### PR TITLE
add `dataclasses` to the list of prerequisite packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     keywords=[
         'music language', 'use codes to write music', 'music language for AI'
     ],
-    install_requires=['mido-fix', 'pygame'],
+    install_requires=['mido-fix', 'pygame','dataclasses'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
我在python 3.6.8 (conda base env)/windows安裝musicpy
在import時出現:
> ModuleNotFoundError: No module named 'dataclasses'
為避免此問題，我在`setup.py`第19行加入:
```python=
    install_requires=['mido-fix', 'pygame','dataclasses'],
```