### PR TITLE
Add extras_require in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,19 @@ Run the following line in the terminal to install musicpy by pip.
 pip install musicpy
 ```
 
+If you need to read and write musicxml files, you can install the relevant dependencies by adding `[musicxml]` after the above command. If you need to use the raw module (musicpy.daw), you can install the relevant dependencies by adding `[daw]`. Like this:
+
+```shell
+pip install musicpy[musicxml]
+pip install musicpy[daw]
+pip install musicpy[daw, musicxml]
+```
+
 **Note 1: On Linux, you need to make sure the installed pygame version is older than 2.0.3, otherwise the play function of musicpy won't work properly, this is due to an existing bug with newer versions of pygame. You can run `pip install pygame==2.0.2` in terminal to install pygame 2.0.2 or any version that is older than 2.0.3. You also need to install freepats to make the play function works on Linux, you can run `sudo apt-get install freepats` (on Ubuntu).**
 
 **Note 2: If you cannot hear any sound when running the play function, this is because some IDE won't wait till the pygame's playback ends, they will stops the whole process after all of the code are executed without waiting for the playback. You can set `wait=True` in the parameter of the play function, which will block the function till the playback ends, so you can hear the sounds.**
+
+**Note 3: If you are using Linux or macOS, one of the dependency libraries of the daw module, sf2_loader, has some necessary configuration steps, you can refer to [here](https://github.com/Rainbow-Dreamer/sf2_loader#installation) for details.**
 
 In addition, I also wrote a musicpy editor for writing and compiling musicpy code more easily than regular python IDE with real-time automatic compilation and execution, there are some syntactic sugar and you can listen to the music generating from your musicpy code on the fly, it is more convenient and interactive. I strongly recommend to use this musicpy editor to write musicpy code. You can download this musicpy editor at the repository [musicpy_editor](https://github.com/Rainbow-Dreamer/musicpy_editor), the preparation steps are in the README.
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -26,9 +26,19 @@ Musicpy可以让你用非常简洁的语法来表达一段音乐的音符，和�
 pip install musicpy
 ```
 
+如果需要读写musicxml文件，你可以在上述命令后面加入`[musicxml]`来安装相关依赖。如果需要使用宿主模块(musicpy.daw)，则通过加入`[daw]`来安装相关依赖。就像这样：
+
+```shell
+pip install musicpy[musicxml]
+pip install musicpy[daw]
+pip install musicpy[daw, musicxml]
+```
+
 **注意事项1: 在Linux上，你需要确保安装的pygame版本早于2.0.3，否则musicpy的play函数将不能正常运行，这是由于pygame的较新版本的一个现有bug。你可以在终端运行`pip install pygame==2.0.2`来安装pygame 2.0.2或任何早于2.0.3的版本。你还需要安装freepats以使play函数在Linux上运行，你可以运行`sudo apt-get install freepats`（在Ubuntu上）。**
 
 **注意事项2: 如果你在运行play函数时听不到任何声音，这是因为有些IDE不会等待pygame的播放结束，他们会在所有代码执行完后停止整个过程，而不等待播放。你可以在播放函数的参数中设置 `wait=True`，这将阻塞该函数直到播放结束，这样你就可以听到声音了。**
+
+**注意事项3: 如果你使用的是Linux或者macOS，daw模块的其中一个依赖库sf2_loader有一些必须的配置步骤，详情请看[这里](https://github.com/Rainbow-Dreamer/sf2_loader#installation)。**
 
 除此之外，我为musicpy专门写了一个编辑器，你可以在这里写musicpy的代码，这个编辑器可以实时自动编译和运行，比在常规的python IDE里更加方便。这个编辑器有一些语法糖，并且你可以实时地听到你写的musicpy代码生成的音乐，更加地方便与互动。我强烈推荐大家使用这个musicpy编辑器来写musicpy代码。你可以在仓库[musicpy_editor](https://github.com/Rainbow-Dreamer/musicpy_editor)下载musicpy editor, 准备步骤在README。
 

--- a/musicpy/requirements.txt
+++ b/musicpy/requirements.txt
@@ -1,3 +1,3 @@
 mido-fix
 pygame-ce
-dataclasses
+dataclasses;python_version<"3.7"

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     keywords=[
         'music language', 'use codes to write music', 'music language for AI'
     ],
-    install_requires=['mido-fix', 'pygame-ce', 'dataclasses'],
+    install_requires=['mido-fix', 'pygame-ce', 'dataclasses;python_version<"3.7"'],
     extras_require={
         "daw": ["sf2_loader", "pedalboard", "scipy", "numpy"],
         "musicxml": ["partitura"],

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ setup(
         'music language', 'use codes to write music', 'music language for AI'
     ],
     install_requires=['mido-fix', 'pygame-ce', 'dataclasses'],
+    extras_require={
+        "daw": ["sf2_loader", "pedalboard", "scipy", "numpy"],
+    },
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     install_requires=['mido-fix', 'pygame-ce', 'dataclasses'],
     extras_require={
         "daw": ["sf2_loader", "pedalboard", "scipy", "numpy"],
+        "musicxml": ["partitura"],
     },
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
PR 做了什么：

1. 将 daw 和 musicxml 所需安装的依赖包通过 `extras_require` 支持。以后可以通过 `pip install musicpy[daw]` 来安装 daw 的依赖包。
2. 修改 README.md README_cn.md，让其他人知晓该方法。
3. 限制 `dataclasses` 第三方库只能在 `python_version < "3.7"` 时安装（其于 Python3.7 作为标准库的一部分）

还需要商讨的部分：

1. 是否需要将 `musicpy` 的 `python_version` 限制在 3.6 及以上（现在 python 版本要求没有任何限制）